### PR TITLE
EPTS-116: Update DSTP and TSTP NATS subjects

### DIFF
--- a/0013/README.md
+++ b/0013/README.md
@@ -34,7 +34,7 @@ The following terms and definitions are used in this RFC.
 
 In order to send endpoint data samples to receivers, transmitters MUST [broadcast](/0003/README.md#broadcast-messaging) `EndpointDataSamplesEvent` messages to the following NATS subject:
 ```
-kaa.v1.events.<transmitter-service-instance-name>.endpoint.data-collection.data-received
+kaa.v1.events.<transmitter-service-instance-name>.endpoint.data-collection.data-samples-received
 ```
 where `<transmitter-service-instance-name>` is the instance name of the transmitter service.
 Allows listeners to subscribe to events from a specific transmitter.

--- a/0014/README.md
+++ b/0014/README.md
@@ -37,7 +37,7 @@ Data point value and tags value can be of arbitrary primitive or composite data 
 
 In order to send endpoint data points to receivers, transmitters MUST [broadcast](/0003/README.md#broadcast-messaging) endpoint time series events to the following NATS subjects:
 ```
-kaa.v1.events.<transmitter-service-instance-name>.endpoint.data-collection.time-series-received.<time-series-name>
+kaa.v1.events.<transmitter-service-instance-name>.endpoint.data-collection.data-points-received.<time-series-name>
 ```
 
 where:


### PR DESCRIPTION
Update DSTP NATS subject to `kaa.v1.events.<transmitter-service-instance-name>.endpoint.data-collection.data-samples-received`